### PR TITLE
Rewrite the whole grammar based on SATySFi's lexer

### DIFF
--- a/grammars/satysfi.cson
+++ b/grammars/satysfi.cson
@@ -179,7 +179,7 @@ repository:
         name: "keyword.control.let-in.satysfi"
       }
       {
-        match: "(@(import|require))(:)(.*)$"
+        match: "(@(import|require))(:)\\s*(.*)$"
         captures:
           1:
             name: "keyword.control.header.$2.satysfi"

--- a/grammars/satysfi.cson
+++ b/grammars/satysfi.cson
@@ -107,6 +107,9 @@ repository:
         include: "#transitionFromBlockState"
       }
       {
+        include: "#itemizePackage"
+      }
+      {
         include: "#blockCommand"
       }
       {
@@ -673,5 +676,30 @@ repository:
       {
         match: "(?<![\\w-])(start-path|(?:line|bezier)-to|close-with-(?:line|bezier)|(?:terminate|unite)-path|fill|stroke|draw-text)(?![\\w-])"
         name: "support.function.builtin.graphic.satysfi"
+      }
+    ]
+  itemizePackage:
+    patterns: [
+      {
+        begin: "(\\+listing)(?:\\s*)(\\{)"
+        beginCaptures:
+          1:
+            name: "support.function.listing.satysfi"
+          2:
+            name: "punctuation.definition.argument.inline.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.definition.argument.inline.end.satysfi"
+        contentName: "meta.state.inline.satysfi"
+        patterns: [
+          {
+            match: "^(?:\\s*)(\\*+)"
+            name: "variable.unordered.list.satysfi"
+          }
+          {
+            include: "#inlineState"
+          }
+        ]
       }
     ]

--- a/grammars/satysfi.cson
+++ b/grammars/satysfi.cson
@@ -261,7 +261,6 @@ repository:
         match: "([A-Z][-a-zA-Z0-9]*\\.)+(?=[a-z][-a-zA-Z0-9]*)"
         name: "support.class.constructor.satysfi"
       }
-
       {
         match: "\\?:"
         name: "punctuation.definition.optional-argument.satysfi"

--- a/grammars/satysfi.cson
+++ b/grammars/satysfi.cson
@@ -106,6 +106,24 @@ repository:
       {
         include: "#transitionFromBlockState"
       }
+      {
+        include: "#blockCommand"
+      }
+      {
+        begin: "<"
+        beginCaptures:
+          0:
+            name: "punctuation.bracket.triangle.begin.satysfi"
+        end: ">"
+        endCaptures:
+          0:
+            name: "punctuation.bracket.triangle.end.satysfi"
+        patterns: [
+          {
+            include: "#blockState"
+          }
+        ]
+      }
     ]
   inlineState:
     patterns: [
@@ -119,25 +137,245 @@ repository:
         include: "#transitionFromInlineState"
       }
       {
+        include: "#inlineCommand"
+      }
+      {
         match: "\\\\[ -@\\[-`{-~]"
         name: "constant.character.escape.satysfi"
       }
     ]
   mathState:
     patterns: [
-      include: "#comment"
-      include: "#transitionFromMathState"
+      {
+        include: "#comment"
+      }
+      {
+        include: "#transitionFromMathState"
+      }
+      {
+        match: "\\\\[a-zA-Z][-a-zA-Z0-9]*"
+        name: "support.function.command.math.satysfi"
+      }
     ]
   transitionFromProgramState:
-    patterns: []
-  transitionFromActiveState:
-    patterns: []
+    patterns: [
+      {
+        begin: "\\{"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.program-to-inline.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.transition.program-to-inline.end.satysfi"
+        contentName: "meta.state.inline.satysfi"
+        patterns: [
+          {
+            include: "#inlineState"
+          }
+        ]
+      }
+      {
+        begin: "'<"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.program-to-block.begin.satysfi"
+        end: ">"
+        endCaptures:
+          0:
+            name: "punctuation.transition.program-to-block.end.satysfi"
+        contentName: "meta.state.block.satysfi"
+        patterns: [
+          {
+            include: "#blockState"
+          }
+        ]
+      }
+      {
+        begin: "\\$\\{"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.program-to-math.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.transition.program-to-math.end.satysfi"
+        patterns: [
+          {
+            include: "#mathState"
+          }
+        ]
+      }
+    ]
   transitionFromBlockState:
-    patterns: []
+    patterns: [
+      {
+        begin: "\\{"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.block-to-inline.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.transition.block-to-inline.end.satysfi"
+        contentName: "meta.state.inline.satysfi"
+        patterns: [
+          {
+            include: "#inlineState"
+          }
+        ]
+      }
+    ]
   transitionFromInlineState:
-    patterns: []
+    patterns: [
+      {
+        begin: "<"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.inline-to-block.begin.satysfi"
+        end: ">"
+        endCaptures:
+          0:
+            name: "punctuation.transition.inline-to-block.end.satysfi"
+        patterns: [
+          {
+            include: "#blockState"
+          }
+        ]
+      }
+      {
+        begin: "\\$\\{"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.inline-to-math.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.transition.inline-to-math.end.satysfi"
+        patterns: [
+          {
+            include: "#mathState"
+          }
+        ]
+      }
+    ]
   transitionFromMathState:
-    patterns: []
+    patterns: [
+      {
+        begin: "!\\{"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.math-to-inline.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.transition.math-to-inline.end.satysfi"
+        patterns: [
+          {
+            include: "#inlineState"
+          }
+        ]
+      }
+      {
+        begin: "!<"
+        beginCaptures:
+          0:
+            name: "punctuation.transition.math-to-block.begin.satysfi"
+        end: ">"
+        endCaptures:
+          0:
+            name: "punctuation.transition.math-to-block.end.satysfi"
+        patterns: [
+          {
+            include: "#blockState"
+          }
+        ]
+      }
+      {
+        begin: "!\\("
+        beginCaptures:
+          0:
+            name: "punctuation.transition.math-to-program.begin.satysfi"
+        end: "\\)"
+        endCaptures:
+          0:
+            name: "punctuation.transition.math-to-program.end.satysfi"
+        patterns: [
+          {
+            include: "#programState"
+          }
+        ]
+      }
+    ]
+  blockCommand:
+    patterns: [
+      {
+        begin: "(\\+[a-zA-Z][-a-zA-Z0-9]*)([^;<]*?)(\\{)"
+        beginCaptures:
+          1:
+            name: "support.function.command.block.satysfi"
+          2:
+            name: "meta.state.active.satysfi"
+            patterns: [
+              {
+                include: "#activeState"
+              }
+            ]
+          3:
+            name: "punctuation.definition.inline.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.definition.inline.end.satysfi"
+        contentName: "meta.state.inline.satysfi"
+        patterns: [
+          {
+            include: "#inlineState"
+          }
+        ]
+      }
+      {
+        begin: "(\\+[a-zA-Z][-a-zA-Z0-9]*)([^;{]*?)(<)"
+        beginCaptures:
+          1:
+            name: "support.function.command.block.satysfi"
+          2:
+            name: "meta.state.active.satysfi"
+            patterns: [
+              {
+                include: "#activeState"
+              }
+            ]
+          3:
+            name: "punctuation.definition.block.begin.satysfi"
+        end: ">"
+        endCaptures:
+          0:
+            name: "punctuation.definition.block.end.satysfi"
+        contentName: "meta.state.block.satysfi"
+        patterns: [
+          {
+            include: "#blockState"
+          }
+        ]
+      }
+      {
+        begin: "\\+[a-zA-Z][-a-zA-Z0-9]*"
+        beginCaptures:
+          0:
+            name: "support.function.command.block.satysfi"
+        end: ";"
+        endCaptures:
+          0:
+            name: "punctuation.definition.terminator.satysfi"
+        contentName: "meta.state.active.satysfi"
+        patterns: [
+          {
+            include: "#activeState"
+          }
+        ]
+      }
+    ]
   comment:
     match: "(%).*"
     captures:
@@ -170,6 +408,75 @@ repository:
       {
         match: "(?:[0-9]+\\.[0-9]*|\\.[0-9]+|[1-9]+[0-9]*|0)(?:pt|mm|cm|inch)"
         name: "constant.numeric.length.satysfi"
+      }
+    ]
+  inlineCommand:
+    patterns: [
+      {
+        begin: "(\\\\[a-zA-Z][-a-zA-Z0-9]*)([^;<]*?)(\\{)"
+        beginCaptures:
+          1:
+            name: "support.function.command.inline.satysfi"
+          2:
+            name: "meta.state.active.satysfi"
+            patterns: [
+              {
+                include: "#activeState"
+              }
+            ]
+          3:
+            name: "punctuation.definition.inline.begin.satysfi"
+        end: "\\}"
+        endCaptures:
+          0:
+            name: "punctuation.definition.inline.end.satysfi"
+        contentName: "meta.state.inline.satysfi"
+        patterns: [
+          {
+            include: "#inlineState"
+          }
+        ]
+      }
+      {
+        begin: "(\\\\[a-zA-Z][-a-zA-Z0-9]*)([^;{]*?)(<)"
+        beginCaptures:
+          1:
+            name: "support.function.command.inline.satysfi"
+          2:
+            name: "meta.state.active.satysfi"
+            patterns: [
+              {
+                include: "#activeState"
+              }
+            ]
+          3:
+            name: "punctuation.definition.block.begin.satysfi"
+        end: ">"
+        endCaptures:
+          0:
+            name: "punctuation.definition.block.end.satysfi"
+        contentName: "meta.state.block.satysfi"
+        patterns: [
+          {
+            include: "#blockState"
+          }
+        ]
+      }
+      {
+        begin: "\\\\[a-zA-Z][-a-zA-Z0-9]*"
+        beginCaptures:
+          0:
+            name: "support.function.command.inline.satysfi"
+        end: ";"
+        endCaptures:
+          0:
+            name: "punctuation.definition.terminator.satysfi"
+        contentName: "meta.state.active.satysfi"
+        patterns: [
+          {
+            include: "#activeState"
+          }
+        ]
       }
     ]
   keyword:

--- a/grammars/satysfi.cson
+++ b/grammars/satysfi.cson
@@ -6,30 +6,230 @@ fileTypes: [
 ]
 patterns: [
   {
-    include: "#commentState"
-  }
-  {
-    include: "#literalState"
-  }
-  {
-    include: "#markup"
-  }
-  {
-    # The program layer seems to have a dedicated file extension "satyh"
-    # althoguh I'm not familiar with the language spec.
-    # This program repository might be migrated into another CSON in the future.
-    include: "#program"
+    include: "#programState"
   }
 ]
 repository:
-  commentState:
+  programState:
+    patterns:[
+      {
+        include: "#comment"
+      }
+      {
+        include: "#literal"
+      }
+      {
+        include: "#activeState"
+      }
+      {
+        include: "#transitionFromProgramState"
+      }
+      {
+        include: "#keyword"
+      }
+      {
+        include: "#constant"
+      }
+      {
+        include: "#misc"
+      }
+      {
+        include: "#operator"
+      }
+      {
+        include: "#primitive"
+      }
+    ]
+  activeState:
+    patterns: [
+      {
+        begin: "\\["
+        beginCaptures:
+          0:
+            name: "punctuation.definition.list.begin.satysfi"
+        end: "\\]"
+        endCaptures:
+          0:
+            name: "punctuation.definition.list.end.satysfi"
+        name: "meta.structure.list.satysfi"
+        patterns: [
+          {
+            include: "#programState"
+          }
+          {
+            match: ";"
+            name: "punctuation.definition.list.delimiter.satysfi"
+          }
+        ]
+      }
+      {
+        begin: "\\(\\|"
+        beginCaptures:
+          0:
+            name: "punctuation.definition.record.begin.satysfi"
+        end: "\\|\\)"
+        endCaptures:
+          0:
+            name: "punctuation.definition.record.end.satysfi"
+        name: "meta.structure.record.satysfi"
+        patterns: [
+          include: "#programState"
+          {
+            match: ";"
+            name: "punctuation.definition.record.delimiter.satysfi"
+          }
+        ]
+      }
+      {
+        begin: "\\("
+        beginCaptures:
+          0:
+            name: "punctuation.definition.begin.satysfi"
+        end: "\\)"
+        endCaptures:
+          0:
+            name: "punctuation.definition.end.satysfi"
+        name: "meta.state.program.satysfi"
+        patterns: [
+          include: "#programState"
+        ]
+      }
+      {
+        include: "#transitionFromActiveState"
+      }
+    ]
+  blockState:
+    patterns: [
+      {
+        include: "#comment"
+      }
+      {
+        include: "#transitionFromBlockState"
+      }
+    ]
+  inlineState:
+    patterns: [
+      {
+        include: "#comment"
+      }
+      {
+        include: "#literal"
+      }
+      {
+        include: "#transitionFromInlineState"
+      }
+      {
+        match: "\\\\[ -@\\[-`{-~]"
+        name: "constant.character.escape.satysfi"
+      }
+    ]
+  mathState:
+    patterns: [
+      include: "#comment"
+      include: "#transitionFromMathState"
+    ]
+  transitionFromProgramState:
+    patterns: []
+  transitionFromActiveState:
+    patterns: []
+  transitionFromBlockState:
+    patterns: []
+  transitionFromInlineState:
+    patterns: []
+  transitionFromMathState:
+    patterns: []
+  comment:
     match: "(%).*"
     captures:
       0:
         name: "comment.line.percentage.satysfi"
       1:
         name: "punctuation.definition.comment.satysfi"
-  literalState:
+  constant:
+    patterns:[
+      {
+        match: "(?<![\\w-])(?:true|false)(?![\\w-])"
+        name: "constant.language.boolean.$0.satysfi"
+      }
+      {
+        match: "\\(\\)"
+        name: "constant.language.unit.satysfi"
+      }
+      {
+        match: "(?:[0-9]+\\.[0-9]*|\\.[0-9]+)"
+        name: "constant.numeric.float.satysfi"
+      }
+      {
+        match: "\\b([1-9]+[0-9]*|0)\\b"
+        name: "constant.numeric.integer.decimal.satysfi"
+      }
+      {
+        match: "\\b(?i:0x[0-9A-F]+)\\b"
+        name: "constant.numeric.integer.hexadecimal.satysfi"
+      }
+      {
+        match: "(?:[0-9]+\\.[0-9]*|\\.[0-9]+|[1-9]+[0-9]*|0)(?:pt|mm|cm|inch)"
+        name: "constant.numeric.length.satysfi"
+      }
+    ]
+  keyword:
+    patterns: [
+      {
+        match: "(?<![\\w-])in(?![\\w-])"
+        name: "keyword.control.let-in.satysfi"
+      }
+      {
+        match: "(@(import|require))(:)(.*)$"
+        captures:
+          1:
+            name: "keyword.control.header.$2.satysfi"
+          3:
+            name: "punctuation.definition.terminator.satysfi"
+          4:
+            name: "support.class.satysfi"
+      }
+      {
+        match: "(?<![\\w-])(?:if|then|else)(?![\\w-])"
+        name: "keyword.control.conditional.satysfi"
+      }
+      {
+        match: "(?<![\\w-])(?:while|do)(?![\\w-])"
+        name: "keyword.control.while.satysfi"
+      }
+      {
+        match: "(?<![\\w-])(?:match|with|when)(?![\\w-])"
+        name: "keyword.control.match.satysfi"
+      }
+      {
+        match: "(?<![\\w-])as(?![\\w-])"
+        name: "keyword.other.as-match.satysfi"
+      }
+      {
+        match: "(?<![\\w-])fun(?![\\w-])"
+        name: "keyword.other.lambda-abstraction.satysfi"
+      }
+      {
+        match: "(?<![\\w-])let(?:-(?:rec|mutable|inline|block|math))?(?![\\w-])"
+        name: "keyword.other.let.satysfi"
+      }
+      {
+        match: "(?<![\\w-])(?:module|struct|sig|val|end|direct)(?![\\w-])"
+        name: "keyword.other.module.satysfi"
+      }
+      {
+        match: "(?<![\\w-])constraint(?![\\w-])"
+        name: "keyword.other.polymorphic-variants.satysfi"
+      }
+      {
+        match: "(?<![\\w-])(?:inline|block|math)-cmd(?![\\w-])"
+        name: "keyword.other.type.builtin-command.satysfi"
+      }
+      {
+        match: "(?<![\\w-])(?:type|of)(?![\\w-])"
+        name: "keyword.other.variant-definition.satysfi"
+      }
+    ]
+  literal:
     begin: "(`+)\\s*"
     beginCaptures:
       1:
@@ -39,38 +239,60 @@ repository:
       1:
         name: "punctuation.definition.string.end.satysfi"
     contentName: "string.quoted.grave-accent.satysfi"
-  program:
+  misc:
     patterns: [
       {
-        include: "#operator"
+        match: "(?<![\\w-])(?:unit|bool|int|float|length|string|(?:inline|block)-(?:text|boxes)|context|(?:pre-)?path|graphics|image|document|math|regexp)(?![\\w-])"
+        name: "storage.type.primitive.satysfi"
       }
       {
-        include: "#primitiveInline"
+        match: "'[a-z][-a-zA-Z0-9]*"
+        name: "keyword.other.type-variable.satysfi"
       }
       {
-        include: "#primitiveBlock"
+        match: "\\\\[a-zA-Z][-a-zA-Z0-9]*"
+        name: "support.function.command.inline.satysfi"
       }
       {
-        include: "#primitiveContext"
+        match: "\\+[a-zA-Z][-a-zA-Z0-9]*"
+        name: "support.function.command.block.satysfi"
       }
       {
-        include: "#primitiveMath"
+        match: "([A-Z][-a-zA-Z0-9]*\\.)+(?=[a-z][-a-zA-Z0-9]*)"
+        name: "support.class.constructor.satysfi"
+      }
+
+      {
+        match: "\\?:"
+        name: "punctuation.definition.optional-argument.satysfi"
       }
       {
-        include: "#primitiveImage"
+        match: "(?<!:):(?!:)"
+        name: "punctuation.definition.type-specification.satysfi"
       }
       {
-        include: "#primitiveGraphic"
-      }
-      {
-        include: "#primitiveType"
+        match: "\\|"
+        name: "punctuation.definition.pattern-match.delimiter.satysfi"
       }
     ]
-  primitiveType:
-    match: "\\b(unit|bool|int|float|length|string|inline-(?:text|boxes))\\b"
-    name: "storage.type.primitive.satysfi"
   operator:
     patterns: [
+      {
+        match: "::"
+        name: "keyword.operator.cons.satysfi"
+      }
+      {
+        match: "<-"
+        name: "keyword.operator.overwrite.satysfi"
+      }
+      {
+        match: "->"
+        name: "keyword.operator.arrow.satysfi"
+      }
+      {
+        match: "="
+        name: "keyword.operator.assignment.satysfi"
+      }
       {
         match: "(\\+|-)\\."
         name: "keyword.operator.arithmetic.float.satysfi"
@@ -92,7 +314,7 @@ repository:
         name: "keyword.operator.bond.inline.satysfi"
       }
       {
-        match: "(\\+|-|\\*|/|mod)"
+        match: "(\\+|(?<![-a-zA-Z0-9<>])-(?![-a-zA-Z0-9<>])|\\*|/|(?<![\\w-])mod(?![\\w-]))"
         name: "keyword.operator.arithmetic.int.satysfi"
       }
       {
@@ -100,12 +322,16 @@ repository:
         name: "keyword.operator.comparison.int.satysfi"
       }
       {
-        match: "(&&|\\|\\||not)"
+        match: "\\^"
+        name: "keyword.operator.concatenation.string.satysfi"
+      }
+      {
+        match: "(&&|\\|\\||(?<![\\w-])not(?![\\w-]))"
         name: "keyword.operator.logical.satysfi"
       }
       {
-        match: "\\^"
-        name: "keyword.operator.concatenation.string.satysfi"
+        match: "!"
+        name: "keyword.operator.dereference.satysfi"
       }
       {
         match: "(arabic|string-unexplode)"
@@ -116,134 +342,30 @@ repository:
         name: "invalid.deprecated.string.satysfi"
       }
     ]
-  primitiveInline:
-    match: "(read-inline|inline-(?:skip|glue|fill|nil|graphics|frame-(?:inner|outer|breakable))|embed-(?:string|math|block-(?:top|bottom))|discretionary|script-guard|get-natural-width|line-stack-(?:top|bottom))"
-    name: "support.function.builtin.inline.satysfi"
-  primitiveBlock:
-    match: "(read-block|line-break|form-document|block-(?:nil|frame-breakable))"
-    name: "support.function.builtin.block.satysfi"
-  primitiveContext:
-    match: "((?:set|get)-(?:font-size|language|dominant-(?:narrow|wide)-script)|set-(?:space-ratio|(?:math-)?font|text-color|leading|manual-rising)|get-text-width)"
-    name: "support.function.builtin.context.satysfi"
-  primitiveMath:
-    match: "(math-(?:(?:big-)?char(?:-with-kern)?|sup|sub|upper|lower|frac|radical|paren|variant-char|color|char-class)|text-in-math)"
-    name: "support.function.builtin.math.satysfi"
-  primitiveImage:
-    match: "(load-(?:pdf-)?image|use-image-by-width)"
-    name: "support.function.builtin.image.satysfi"
-  primitiveGraphic:
-    match: "(start-path|(?:line|bezier)-to|close-with-(?:line|bezier)|(?:terminate|unite)-path|fill|stroke|draw-text)"
-    name: "support.function.builtin.graphic.satysfi"
-  markup:
+  primitive:
     patterns: [
       {
-        include: "#packageLoading"
+        match: "(?<![\\w-])(read-inline|inline-(?:skip|glue|fill|nil|graphics|frame-(?:inner|outer|breakable))|embed-(?:string|math|block-(?:top|bottom))|discretionary|script-guard|get-natural-width|line-stack-(?:top|bottom))(?![\\w-])"
+        name: "support.function.builtin.inline.satysfi"
       }
       {
-        # This will be divided into several parts with more comprehensive names
-        # once I get familiar with the grammar.
-        include: "#misc"
-      }
-    ]
-  packageLoading:
-    match: "@(import|require):"
-    name: "keyword.control.$1.satysfi"
-  misc:
-    patterns: [
-      {
-        begin: "(document)\\s+\\(\\|"
-        beginCaptures:
-          1:
-            name: "keyword.other.document.satysfi"
-        end: "\\|\\)"
-        patterns: [
-          {
-            match: "(title|author)\\s*(=)\\s*(.+);"
-            captures:
-              1:
-                name: "keyword.other.document-metadata.$1.satysfi"
-              2:
-                name: "punctuation.separator.key-value.satysfi"
-          }
-          {
-            match: "(show-(?:title|toc))\\s*(=)\\s*(true|false);"
-            captures:
-              1:
-                name: "keyword.other.document-metadata.$1.satysfi"
-              2:
-                name: "punctuation.separator.key-value.satysfi"
-              3:
-                name: "constant.language.boolean.$3.satysfi"
-          }
-        ]
+        match: "(?<![\\w-])(read-block|line-break|form-document|block-(?:nil|frame-breakable))(?![\\w-])"
+        name: "support.function.builtin.block.satysfi"
       }
       {
-        begin: "{"
-        beginCaptures:
-          0:
-            name: "punctuation.definition.argument.inline-direction.begin.satysfi"
-        end: "}"
-        endCaptures:
-          0:
-            name: "punctuation.definition.argument.inline-direction.end.satysfi"
+        match: "(?<![\\w-])((?:set|get)-(?:font-size|language|dominant-(?:narrow|wide)-script)|set-(?:space-ratio|(?:math-)?font|text-color|leading|manual-rising)|get-text-width)(?![\\w-])"
+        name: "support.function.builtin.context.satysfi"
       }
       {
-        begin: "(\\+(section))\\s*(?:\\?:\\(`(.*?)`\\))?\\s*{.*?}(<)"
-        beginCaptures:
-          1:
-            name: "markup.heading.$2.satysfi"
-          3:
-            name: "constant.other.label.satysfi"
-          4:
-            name: "punctuation.definition.argument.block-direction.begin.satysfi"
-        end: ">"
-        endCaptures:
-          0:
-            name: "punctuation.definition.argument.block-direction.end.satysfi"
-        patterns: [
-          {
-            include: "$self"
-          }
-        ]
+        match: "(?<![\\w-])(math-(?:(?:big-)?char(?:-with-kern)?|sup|sub|upper|lower|frac|radical|paren|variant-char|color|char-class)|text-in-math)(?![\\w-])"
+        name: "support.function.builtin.math.satysfi"
       }
       {
-        begin: "(\\+pn?)({)"
-        beginCaptures:
-          1:
-            name: "support.other.paragraph.satysfi"
-          2:
-            name: "punctuation.definition.argument.inline-direction.begin.satysfi"
-        end: "}"
-        endCaptures:
-          0:
-            name: "punctuation.definition.argument.inline-direction.end.satysfi"
-        patterns: [
-          {
-            include: "$self"
-          }
-        ]
+        match: "(?<![\\w-])(load-(?:pdf-)?image|use-image-by-width)(?![\\w-])"
+        name: "support.function.builtin.image.satysfi"
       }
       {
-        begin: "(\\+listing)({)"
-        beginCaptures:
-          1:
-            name: "support.other.listing.itemize.satysfi"
-          2:
-            name: "punctuation.definition.argument.inline-direction.begin.satysfi"
-        end: "}"
-        endCaptures:
-          0:
-            name: "punctuation.definition.argument.inline-direction.end.satysfi"
-        patterns: [
-          {
-            match: "^\\s*(\\*+)\\s+"
-            captures:
-              1:
-                name: "variable.unordered.list.satysfi"
-          }
-          {
-            include: "$self"
-          }
-        ]
+        match: "(?<![\\w-])(start-path|(?:line|bezier)-to|close-with-(?:line|bezier)|(?:terminate|unite)-path|fill|stroke|draw-text)(?![\\w-])"
+        name: "support.function.builtin.graphic.satysfi"
       }
     ]


### PR DESCRIPTION
This PR attempts to conform to the SATySFi's _states_, transitions between which are summarized [here](https://github.com/gfngfn/SATySFi/blob/12ebe51037e44186e470143f5f9d06b5585230dc/src/frontend/lexer.mll#L7-L21). The main motivation is to make the grammar state-sensitive.

Grammar for transitions are basically simple, but transitions from active state to other are a bit tough to implement, thus pending as WIP.

