### PR TITLE
Unscope the leading whitespaces before bullets

### DIFF
--- a/grammars/satysfi.cson
+++ b/grammars/satysfi.cson
@@ -694,8 +694,10 @@ repository:
         contentName: "meta.state.inline.satysfi"
         patterns: [
           {
-            match: "^(?:\\s*)(\\*+)"
-            name: "variable.unordered.list.satysfi"
+            match: "^\\s*(\\*+)"
+            captures:
+              1:
+                name: "variable.unordered.list.satysfi"
           }
           {
             include: "#inlineState"


### PR DESCRIPTION
Consider the following snippet:

```
'<
  +listing{
    * foo
  }
>
```

The leading spaces in line 3 are currently scopes as `variable.unordered.list.satysfi`.

![2018-03-25 22 31 40](https://user-images.githubusercontent.com/13291527/37875655-764d2c96-307d-11e8-9e9b-ac901e11bd4f.png)

This PR fix the behavior so that only asterisks are scoped as such